### PR TITLE
Reset ComfyUI's persisted UI state before each navigation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -39,9 +39,23 @@ COMFYUI_URL=http://127.0.0.1:8188 npm test
 - `flow-measurement.spec.ts`：第二次运行时重新测量大小、折叠节点及预览/应用一致性。
 - `history-input-color.spec.ts`：单步撤销、输入框快捷键隔离和颜色撤销。
 - `panel-toast.spec.ts`：面板位置、刷新、侧栏/属性按钮碰撞和 toast 点击穿透。
+- `panel-drag.spec.ts`：拖动手柄/标题栏、点击仍可切换、位置持久化与重置、越界钳制。
+- `panel-header.spec.ts`：标题与控件在 320–1600px 各宽度下不重叠、不截断（默认 / 拖动后 / 刷新后）。
 
-最新 `origin/test` (`774ec13`) 完整 Google Chrome 结果：**16 passed, 1 failed, 1 skipped**。
-唯一失败是折叠后的 Housekeeper 手柄覆盖 ComfyUI 属性按钮；legacy docked sidebar 在当前前端不存在，因此相应 resize 检查跳过。
+## 测试隔离
+
+ComfyUI 把部分界面状态存在**服务端**（`user/default/comfy.settings.json`），
+不是 localStorage，所以换 context 或清浏览器存储都重置不了。
+任何切换右侧面板的用例都会改变后续用例的初始状态，结果因执行顺序而变：
+同一份代码连续跑两次曾分别得到 2 个和 1 个失败，而单独跑这些用例都能通过。
+
+因此 `openComfyUI()` 会先调用 `resetComfyUIState()`，
+通过 `POST /api/settings` 把这些键恢复到固定基线后再导航。
+基线特意让右侧面板保持关闭——这是面板定位更难的情况：
+面板打开时有一大块明显的障碍物可测量，关闭时只剩右上角一小组控件需要避让。
+
+新增依赖服务端状态的用例时，请把对应的键加入 helper 里的 `UI_STATE_BASELINE`，
+否则套件会重新变得依赖执行顺序，无法作为合并门禁。
 
 默认运行使用 headless Chrome，避免测试窗口抢占当前桌面焦点。只有明确需要观察交互时才运行 `npm run test:headed`。
 

--- a/e2e/tests/helpers/comfyui.ts
+++ b/e2e/tests/helpers/comfyui.ts
@@ -29,7 +29,42 @@ export type NodeSnapshot = {
 
 export type Rect = { x: number; y: number; width: number; height: number }
 
+/**
+ * UI state that tests toggle and that ComfyUI persists SERVER-SIDE, in
+ * user/default/comfy.settings.json - not in localStorage, so clearing browser storage or
+ * using a fresh context does not reset it.
+ *
+ * Without this, a test that opens the right side panel changes the starting conditions of
+ * every test after it, and results depend on execution order: the same suite run twice on
+ * identical code produced 2 failures and then 1, and tests that failed in sequence passed
+ * in isolation. That makes the suite unusable as a merge gate, because a real regression is
+ * indistinguishable from ordering noise.
+ *
+ * The baseline deliberately closes the right side panel. That is the harder case for panel
+ * placement - with the panel open there is a wide, obvious obstacle to measure against;
+ * closed, only the narrow top-right control cluster is there to avoid.
+ */
+const UI_STATE_BASELINE: Record<string, unknown> = {
+  'Comfy.RightSidePanel.IsOpen': false,
+  'Comfy.Queue.History.Expanded': false
+}
+
+/**
+ * Put ComfyUI's persisted UI state back to a known baseline. Must run before navigation so
+ * the page loads with it already applied.
+ */
+export async function resetComfyUIState(page: Page) {
+  const response = await page.request.post('/api/settings', { data: UI_STATE_BASELINE })
+  // Fail loudly rather than silently reintroducing order-dependence if the endpoint moves.
+  expect(
+    response.ok(),
+    `could not reset ComfyUI UI state (HTTP ${response.status()}) - tests would be order-dependent`
+  ).toBe(true)
+}
+
 export async function openComfyUI(page: Page) {
+  await resetComfyUIState(page)
+
   await page.goto('/', { waitUntil: 'domcontentloaded' })
   await page.waitForFunction(() => {
     const app = (window as any).app


### PR DESCRIPTION
Makes the browser suite deterministic. **No `src/` changes** — this is test infrastructure only.

## The cause

ComfyUI stores part of its interface state **server-side**, in `user/default/comfy.settings.json`:

```json
{ "Comfy.RightSidePanel.IsOpen": false, "Comfy.Queue.History.Expanded": true }
```

Not localStorage. A fresh browser context doesn't reset it, and neither does clearing browser storage — so every test that opened the right side panel changed the starting conditions of every test after it.

The suite was measuring execution order as much as the product: identical code produced **2 failures, then 1** on consecutive runs, and tests that failed in sequence passed in isolation. That's also why your run and mine disagreed on *which* tests failed — different persisted state on each machine.

## The fix

`openComfyUI()` now calls `resetComfyUIState()` first, restoring a fixed baseline via `POST /api/settings` before navigating.

The baseline deliberately leaves the right side panel **closed** — that's the harder case for panel placement. With the panel open there's a wide, obvious obstacle to measure against; closed, only the narrow top-right control cluster remains to avoid, which is exactly where #31's bug lived.

A failed reset throws rather than silently reintroducing order-dependence, so this can't rot quietly if the endpoint moves.

## Result

| | Before | After |
| --- | --- | --- |
| Full run 1 | 33 passed, 1 failed | **34 passed, 0 failed** |
| Full run 2 | 33 passed, 1 failed | **34 passed, 0 failed** |
| `panel-toast` × 3 | varied | 5/5 every time |

The suite can now serve as a merge gate.

## This answers the open question in #25

The expanded-panel assertion had failed **5 of 8** full runs. It now passes across 3 isolated runs and 2 full runs with no source change — so the remaining failure was **test isolation, not the panel covering ComfyUI's chrome**. #31's fix was complete; I just couldn't prove it against a suite that wasn't measuring the product.

I'll close #25 once this is on `test`, noting the collapsed-handle fix shipped in #31 and the residual doubt was the harness.

## Also

Updates `e2e/README.md`: adds the two new specs to the list, replaces the stale results line (it still cited `774ec13` and 16/1/1), and documents the isolation contract — including that new server-state-dependent tests must add their keys to `UI_STATE_BASELINE`, or the suite silently becomes order-dependent again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
