### PR TITLE
Warm the frontend before running the browser suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,6 +98,28 @@ jobs:
             || { echo "::error::the extension bundle is not being served"; exit 1; }
           echo "extension loaded and its bundle is served"
 
+      # The first page load pays for ComfyUI's frontend initialising, which on a 2-core
+      # runner exceeded the per-test timeout and failed whichever test happened to run
+      # first - in beforeEach, before it asserted anything. Paying that cost here keeps it
+      # out of the suite instead of masking it with retries.
+      - name: Warm up the frontend
+        working-directory: extension/e2e
+        run: |
+          node --input-type=module -e "
+          import { chromium } from '@playwright/test';
+          const browser = await chromium.launch({ channel: 'chrome' });
+          const page = await browser.newPage();
+          await page.goto('http://127.0.0.1:8188/', { waitUntil: 'domcontentloaded' });
+          await page.waitForFunction(
+            () => Boolean(window.app?.graph && window.app?.canvas && window.LiteGraph),
+            null,
+            { timeout: 180000 }
+          );
+          await page.waitForSelector('.housekeeper-wrapper', { timeout: 60000 });
+          console.log('frontend warm: app ready and the Housekeeper panel is attached');
+          await browser.close();
+          "
+
       - name: Run browser tests
         working-directory: extension/e2e
         env:


### PR DESCRIPTION
Fixes the one failure from the browser workflow's first real run.

## What happened

The run was **56/57**. The single failure was whichever test happened to go first:

```
Test timeout of 120000ms exceeded while running "beforeEach" hook.
  waiting for getByRole('button', { name: 'Housekeeper', exact: true })
```

It never asserted anything — it died in `beforeEach`. Every later test took **4–11s**, including the very next test in the same file.

That's cold start, not flakiness. The first page load pays for ComfyUI's frontend initialising, and on a 2-core runner that exceeds the per-test timeout. It doesn't reproduce locally on 4 cores against an already-warm install, which is why the workflow looked fine until it ran for real.

## The fix

Load the page once before the suite and wait for `window.app` and the panel, so that cost lands in its own step instead of inside whichever test drew the short straw.

## Why not retries

`retries: 1` would have turned this green immediately. It would also have hidden a real two-minute first-load cost, and left the suite unable to distinguish a genuine regression from ordering noise later — the exact problem #34 existed to fix. The warm-up step fails loudly on its own if the frontend never becomes ready, so a real startup failure still surfaces as a startup failure.

## What the run proved

The rest of the workflow worked end to end on first attempt: ComfyUI checked out and installed with CPU torch, started, the extension loaded with no `(IMPORT FAILED)`, its bundle was served, and 56 tests passed against a fresh ComfyUI `master` — not the `27bca65` I'd been testing against locally. That's a useful compatibility signal in itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
