### PR TITLE
Settle before grabbing the panel in the drag suite

### DIFF
--- a/e2e/tests/panel-drag.spec.ts
+++ b/e2e/tests/panel-drag.spec.ts
@@ -34,6 +34,11 @@ test.describe('draggable panel position', () => {
     await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
+    // ComfyUI reflows its own chrome asynchronously after load, and the panel measures its
+    // placement against it. Grabbing the handle before that settles starts the drag from a
+    // stale box, and the move clamps back to where it began. Fast enough locally to hide
+    // this; a 2-core CI runner is not.
+    await page.waitForTimeout(600)
   })
 
   test('the collapsed handle can be dragged, and the drag does not toggle the panel', async ({ page }) => {
@@ -48,8 +53,7 @@ test.describe('draggable panel position', () => {
 
   test('the panel header can be dragged while open, without closing it', async ({ page }) => {
     await openHousekeeper(page)
-    // Expanding changes the wrapper's width, which re-measures the automatic placement.
-    // Let that settle before grabbing the header, or the drag starts from a stale box.
+    // Expanding changes the wrapper's width, which re-measures the placement again.
     await page.waitForTimeout(600)
     const before = await wrapperPosition(page)
     await dragBy(page, '.housekeeper-header', -250, 180)
@@ -78,6 +82,7 @@ test.describe('draggable panel position', () => {
 
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
+    await page.waitForTimeout(600)
     expect(await storedPosition(page)).toBe(stored)
     const restored = await wrapperPosition(page)
     expect(restored.y).toBeGreaterThan(100)


### PR DESCRIPTION
Fixes the two failures from the browser workflow's second run. Test-only — no `src/` changes.

## Progress from the last run

The warm-up in #39 **worked**: the cold-start failure is gone and the suite dropped from timing out to 5.4m. Two different tests failed instead:

```
✘ panel-drag.spec.ts:39  the collapsed handle can be dragged      (6.1s)
✘ panel-drag.spec.ts:74  a dragged position survives a reload      (6.7s)

  Expected: > 48
  Received:   48
```

Both around 6s, so not timeouts — the drag simply didn't move the panel.

## Cause

ComfyUI reflows its own chrome asynchronously after load, and the panel measures its placement against it. Grabbing the handle before that settles starts the drag from a **stale box**, so the computed move clamps back to where it began.

The telling detail: the **header**-drag test in the same file passed — and it's the one test there that already had a settle, added when the keyboard work exposed exactly this. The `beforeEach` had none, so every other test in the file was racing the reflow.

The settle now lives in `beforeEach`, where it should have gone the first time, plus one after the mid-test reload.

## Not a product concern

The window is a few hundred milliseconds after page load, and the worst outcome is a drag starting from a slightly stale origin and clamping. It's fast enough locally on 4 cores to never appear — which is precisely the value of running on a 2-core runner.

## Verified

8/8 locally. Note the first local run showed 8 failures with `ECONNREFUSED 127.0.0.1:8188` — I'd shut the test ComfyUI down earlier at your request, so that was no server, not a regression. Restarted it and re-ran.

## Pattern worth noting

This is the third place the same reflow race has surfaced — `panel-header`, `panel-keyboard`, now `panel-drag`. Each time I fixed the test in front of me instead of the shared helper. A settle inside `openComfyUI()` would have covered all three at once and is the better fix; I've kept this change minimal since it's chasing a red CI run, but that consolidation is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
