### PR TITLE
Wait for the panel to settle in one place, by condition

### DIFF
--- a/e2e/tests/helpers/comfyui.ts
+++ b/e2e/tests/helpers/comfyui.ts
@@ -65,6 +65,44 @@ export async function resetComfyUIState(page: Page) {
   ).toBe(true)
 }
 
+/**
+ * Block until the panel has stopped moving.
+ *
+ * ComfyUI reflows its own chrome asynchronously after load, and the panel measures its
+ * placement against it - so for a few hundred milliseconds the wrapper is still being
+ * repositioned. A test that grabs it during that window drags from a stale box and the move
+ * clamps back to where it started, which is a failure that only appears on slower machines.
+ *
+ * Waits for the wrapper's geometry to be identical across several consecutive samples rather
+ * than sleeping a fixed amount: it returns as soon as things are actually stable, and keeps
+ * waiting on a machine that needs longer.
+ */
+export async function waitForPanelSettled(page: Page, requiredStableSamples = 3) {
+  await page.evaluate(() => {
+    delete (window as any).__hkSettle
+  })
+
+  await page.waitForFunction(
+    (needed: number) => {
+      const element = document.querySelector('.housekeeper-wrapper')
+      if (!element) return false
+
+      const rect = element.getBoundingClientRect()
+      const sample = [rect.x, rect.y, rect.width, rect.height]
+      const state = ((window as any).__hkSettle ??= { last: null, stable: 0 })
+
+      const unchanged =
+        state.last !== null && state.last.every((value: number, i: number) => Math.abs(value - sample[i]) < 0.5)
+
+      state.stable = unchanged ? state.stable + 1 : 0
+      state.last = sample
+      return state.stable >= needed
+    },
+    requiredStableSamples,
+    { polling: 150, timeout: 20_000 }
+  )
+}
+
 export async function openComfyUI(page: Page) {
   await resetComfyUIState(page)
 
@@ -76,6 +114,10 @@ export async function openComfyUI(page: Page) {
 
   await expect(page.locator('canvas').first()).toBeVisible()
   await expect(page.locator('.housekeeper-wrapper')).toBeAttached()
+
+  // Every caller wants a panel that has finished placing itself. Doing it here rather than in
+  // each spec is what stops this being rediscovered a fourth time.
+  await waitForPanelSettled(page)
 }
 
 export async function openHousekeeper(page: Page) {

--- a/e2e/tests/panel-drag.spec.ts
+++ b/e2e/tests/panel-drag.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { openComfyUI, openHousekeeper } from './helpers/comfyui'
+import { openComfyUI, openHousekeeper, waitForPanelSettled } from './helpers/comfyui'
 
 const STORAGE_KEY = 'housekeeper-panel-position'
 
@@ -34,11 +34,6 @@ test.describe('draggable panel position', () => {
     await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
-    // ComfyUI reflows its own chrome asynchronously after load, and the panel measures its
-    // placement against it. Grabbing the handle before that settles starts the drag from a
-    // stale box, and the move clamps back to where it began. Fast enough locally to hide
-    // this; a 2-core CI runner is not.
-    await page.waitForTimeout(600)
   })
 
   test('the collapsed handle can be dragged, and the drag does not toggle the panel', async ({ page }) => {
@@ -53,8 +48,8 @@ test.describe('draggable panel position', () => {
 
   test('the panel header can be dragged while open, without closing it', async ({ page }) => {
     await openHousekeeper(page)
-    // Expanding changes the wrapper's width, which re-measures the placement again.
-    await page.waitForTimeout(600)
+    // Expanding changes the wrapper's width, so its placement is recomputed again.
+    await waitForPanelSettled(page)
     const before = await wrapperPosition(page)
     await dragBy(page, '.housekeeper-header', -250, 180)
 
@@ -82,7 +77,6 @@ test.describe('draggable panel position', () => {
 
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
-    await page.waitForTimeout(600)
     expect(await storedPosition(page)).toBe(stored)
     const restored = await wrapperPosition(page)
     expect(restored.y).toBeGreaterThan(100)

--- a/e2e/tests/panel-header.spec.ts
+++ b/e2e/tests/panel-header.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { openComfyUI, openHousekeeper } from './helpers/comfyui'
+import { openComfyUI, openHousekeeper, waitForPanelSettled } from './helpers/comfyui'
 
 const STORAGE_KEY = 'housekeeper-panel-position'
 type Page = import('@playwright/test').Page
@@ -86,9 +86,8 @@ test.describe('panel header layout', () => {
       await page.reload({ waitUntil: 'domcontentloaded' })
       await openComfyUI(page)
       await openHousekeeper(page)
-      // ComfyUI reflows its own chrome asynchronously after a viewport change, and the panel
-      // measures against it. Let both settle before asserting or dragging.
-      await page.waitForTimeout(600)
+      // Expanding changes the wrapper's width, so its placement is recomputed again.
+      await waitForPanelSettled(page)
 
       const initial = await headerLayout(page)
       expectNoCollisions(initial, `default @${width}`)
@@ -116,7 +115,7 @@ test.describe('panel header layout', () => {
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
     await openHousekeeper(page)
-    await page.waitForTimeout(600)
+    await waitForPanelSettled(page)
     await dragHeader(page, -150, 120)
 
     const reset = page.locator('.housekeeper-reset-position')

--- a/e2e/tests/panel-keyboard.spec.ts
+++ b/e2e/tests/panel-keyboard.spec.ts
@@ -25,7 +25,6 @@ test.describe('keyboard panel positioning', () => {
     await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
     await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
-    await page.waitForTimeout(600)
   })
 
   test('arrow keys move the panel while the handle has focus', async ({ page }) => {


### PR DESCRIPTION
Test-only — no `src/` changes.

## The duplication

The same reflow race was patched **three times in three spec files** — `panel-header`, `panel-keyboard`, `panel-drag` — each time by adding `waitForTimeout(600)` to whichever test had just gone red on CI. Six copies of the same guess, and a fourth occurrence waiting to happen.

ComfyUI reflows its own chrome asynchronously after load and the panel measures its placement against it, so for a few hundred milliseconds the wrapper is still moving. Grabbing it during that window drags from a stale box and the move clamps back to where it started.

## The fix

`openComfyUI()` now ends with `waitForPanelSettled()` — condition-based rather than a sleep:

```ts
const unchanged = state.last !== null &&
  state.last.every((value, i) => Math.abs(value - sample[i]) < 0.5)
state.stable = unchanged ? state.stable + 1 : 0
return state.stable >= needed
```

It polls the wrapper's geometry and returns once it's been identical across three consecutive samples.

That's deliberately better than moving the sleep into the helper. It returns as soon as things are genuinely stable, and **keeps waiting on a machine that needs longer** — which is exactly the failure mode CI kept finding and a 4-core dev box kept hiding. A fixed 600ms would just be the same guess relocated.

## What stays

Two call sites remain in the specs on purpose: expanding the panel changes the wrapper's width and its placement is recomputed again. That's a genuinely different settle, not duplication — it now uses the same condition-based wait instead of a magic number.

## Verified

The three affected specs: 24/24. Full suite: **57 passed, 0 failed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
