### PR TITLE
Find ComfyUI's menu on V1 and Desktop layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **The panel could sit under the menu bar on ComfyUI V1 and Desktop.** Its top offset is measured
+  from ComfyUI's menu, but the selectors used to find that menu matched none of the elements those
+  layouts use, so the panel fell back to a fixed default and overlapped. Reported with a working fix
+  by [@ImagineerNL](https://github.com/ImagineerNL) in
+  [#26](https://github.com/joanna910225/comfyui-housekeeper/pull/26); the selectors are theirs.
+- The same measurement compared a DOM rectangle against zero with exact float equality, so it
+  silently failed at any browser zoom other than 100%.
+
 ## [0.6.0] - 2026-08-12
 
 Housekeeping. Nothing changes in the panel — this release is about what the project ships and
@@ -75,7 +87,9 @@ Panel placement you control. Detail in
 ### Added
 
 - **The panel can be dragged, and remembers where you put it.** Drag the handle when the panel is
-  collapsed, or its header when open. A *Reset position* control appears once the panel has been
+  collapsed, or its header when open. [@ImagineerNL](https://github.com/ImagineerNL) proposed and
+  implemented this independently in [#26](https://github.com/joanna910225/comfyui-housekeeper/pull/26),
+  several months before it shipped here. A *Reset position* control appears once the panel has been
   moved and returns it to the automatic placement. The position is clamped on load and on window
   resize, so a position saved on a larger monitor can never leave the panel somewhere it cannot be
   grabbed again. Closes #22.

--- a/js/main.js
+++ b/js/main.js
@@ -80,8 +80,10 @@ function De() {
   }
   const N2 = 48, B0 = 24;
   function a0() {
-    const e = document.querySelector("#comfyui-body-top, .comfyui-body-top");
-    return e && e.getBoundingClientRect().top === 0 ? e : document.querySelector("#comfy-menu, .comfyui-menu, .litegraph-menu, .comfyui-toolbar");
+    const e = document.querySelector(
+      "header, .comfy-vue-header, #comfyui-body-top, .comfyui-body-top"
+    );
+    return e && Math.abs(e.getBoundingClientRect().top) < 1 ? e : document.querySelector("#comfy-menu, .comfyui-menu, .litegraph-menu, .comfyui-toolbar");
   }
   function _0() {
     const e = a0();

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,12 +273,19 @@ function initializeAlignmentPanel() {
     const PANEL_BOTTOM_MARGIN = 24;
 
     function getTopMenuElement(): HTMLElement | null {
-        // Look for the top menu bar specifically (not bottom menu)
-        const topMenu = document.querySelector<HTMLElement>('#comfyui-body-top, .comfyui-body-top');
-        if (topMenu && topMenu.getBoundingClientRect().top === 0) {
+        // `header` and `.comfy-vue-header` cover the ComfyUI V1 and Desktop layouts, where
+        // none of the ids below exist and the panel would otherwise fall back to a fixed
+        // default offset and sit under the menu. Thanks to @ImagineerNL, who reported this
+        // from a configuration none of the other selectors match (PR #26).
+        const topMenu = document.querySelector<HTMLElement>(
+            'header, .comfy-vue-header, #comfyui-body-top, .comfyui-body-top'
+        );
+        // Tolerance rather than `=== 0`: an exact float comparison against a DOM rect fails
+        // under browser zoom, which silently dropped the menu on any non-100% zoom level.
+        if (topMenu && Math.abs(topMenu.getBoundingClientRect().top) < 1) {
             return topMenu;
         }
-        
+
         // Fallback to any menu if no specific top menu found
         return document.querySelector<HTMLElement>('#comfy-menu, .comfyui-menu, .litegraph-menu, .comfyui-toolbar');
     }


### PR DESCRIPTION
Adopts the fix from [#26](https://github.com/joanna910225/comfyui-housekeeper/pull/26) by @ImagineerNL, and closes it. Targets `test`.

## The bug they found

The panel's top offset is measured from ComfyUI's menu bar. The selectors used to find it — `#comfyui-body-top`, `.comfyui-body-top` and some legacy ids — match **none** of the elements the V1 and Desktop layouts use. There the lookup returns null, the offset falls back to a fixed default, and the panel sits under the menu.

@ImagineerNL hit this in January, diagnosed it correctly, and their `header, .comfy-vue-header` selectors are what's adopted here. Another user confirmed the fix worked in that thread.

## Why their PR couldn't be merged as-is

It patched `js/main.js` — the built bundle — rather than `src/main.ts`. Any `npm run build` would have erased it, and CI now fails on exactly that drift. That was never written down anywhere, which is our documentation gap, not theirs; the README PR adds a Contributing section saying so.

## One more bug in the same three lines

```diff
- if (topMenu && topMenu.getBoundingClientRect().top === 0)
+ if (topMenu && Math.abs(topMenu.getBoundingClientRect().top) < 1)
```

Exact float equality against a DOM rectangle fails at any browser zoom other than 100%, silently dropping the menu and producing the same symptom for a different reason. Worth fixing while in here, since a user hitting it would have reported it as the same problem.

## Credit

@ImagineerNL is credited in the changelog twice: for this fix, and on v0.4.0's draggable panel — which they proposed and implemented **months before it shipped here**. Their PR did the same thing: drag the tab, persist the position, same 4px click-vs-drag threshold, same `cursor: grab`. Had it been picked up in January it would have saved #31, #32 and #33.

## Verification

Unit 18/18. `panel-toast` and `panel-header` (the specs that assert panel placement) 14 passed, 1 skipped — placement is unchanged on the standard layout, which is what the widened selector must not disturb.

Not verified: the V1/Desktop layouts themselves. I have no instance of either, so this rests on their report and on the selectors matching what those layouts render. Flagging that rather than implying I tested it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
