### PR TITLE
Stop paying for page loads the browser suite does not need

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,17 @@ name: Browser tests
 on:
   push:
     branches: [main, test]
+    # Only what can actually change browser behaviour. A README or changelog edit triggering
+    # a nine-minute ComfyUI install teaches people to ignore the result.
+    paths:
+      - 'src/**'
+      - 'js/**'
+      - '__init__.py'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.mts'
   workflow_dispatch:
     inputs:
       comfyui_ref:

--- a/e2e/tests/panel-drag.spec.ts
+++ b/e2e/tests/panel-drag.spec.ts
@@ -30,9 +30,8 @@ test.describe('draggable panel position', () => {
   test.use({ viewport: { width: 1280, height: 800 } })
 
   test.beforeEach(async ({ page }) => {
-    await openComfyUI(page)
-    await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
-    await page.reload({ waitUntil: 'domcontentloaded' })
+    // No need to clear localStorage: Playwright gives each test a fresh browser context, so
+    // it is already empty. Clearing it used to cost a second full ComfyUI page load per test.
     await openComfyUI(page)
   })
 

--- a/e2e/tests/panel-header.spec.ts
+++ b/e2e/tests/panel-header.spec.ts
@@ -81,9 +81,7 @@ test.describe('panel header layout', () => {
   for (const width of WIDTHS) {
     test(`header controls never collide at ${width}px, before and after dragging`, async ({ page }) => {
       await page.setViewportSize({ width, height: 800 })
-      await openComfyUI(page)
-      await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
-      await page.reload({ waitUntil: 'domcontentloaded' })
+      // Fresh context per test: localStorage is already empty.
       await openComfyUI(page)
       await openHousekeeper(page)
       // Expanding changes the wrapper's width, so its placement is recomputed again.
@@ -110,9 +108,6 @@ test.describe('panel header layout', () => {
 
   test('the reset label reads in full rather than being truncated', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
-    await openComfyUI(page)
-    await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
-    await page.reload({ waitUntil: 'domcontentloaded' })
     await openComfyUI(page)
     await openHousekeeper(page)
     await waitForPanelSettled(page)

--- a/e2e/tests/panel-keyboard.spec.ts
+++ b/e2e/tests/panel-keyboard.spec.ts
@@ -21,9 +21,8 @@ test.describe('keyboard panel positioning', () => {
   test.use({ viewport: { width: 1280, height: 800 } })
 
   test.beforeEach(async ({ page }) => {
-    await openComfyUI(page)
-    await page.evaluate(key => window.localStorage.removeItem(key), STORAGE_KEY)
-    await page.reload({ waitUntil: 'domcontentloaded' })
+    // A fresh context per test means localStorage starts empty; clearing it cost a
+    // second full page load.
     await openComfyUI(page)
   })
 


### PR DESCRIPTION
CI-only. No `src/` changes.

## Where the time actually goes

I assumed the ComfyUI + torch install dominated. Measured, it doesn't:

| Step | sec | % |
| --- | ---: | ---: |
| **Run browser tests** | **406** | **77%** |
| Install ComfyUI dependencies | 65 | 12% |
| Install test dependencies | 28 | 5% |
| Start ComfyUI | 20 | 4% |
| Warm up | 4 | 1% |

Caching pip would save about a minute of nine. The tests are the cost.

## And much of that was self-inflicted

The panel specs did this in `beforeEach`:

```js
await openComfyUI(page)                                  // full page load
await page.evaluate(() => localStorage.removeItem(KEY))
await page.reload({ waitUntil: 'domcontentloaded' })      // full page load again
await openComfyUI(page)                                   // …and settle again
```

**Two full ComfyUI loads per test, to clear something already empty.** Playwright gives each test a fresh browser context, so localStorage starts clean.

Verified rather than assumed — a two-test spec that writes a key in the first and reads `null` in the second:

```
leaked value: null
2 passed
```

Removed from roughly 24 tests. The reloads that remain are the ones testing persistence deliberately.

## Path filters

The workflow no longer runs on changes that cannot affect browser behaviour. A README-only pull request (#45) triggered a nine-minute ComfyUI install today. A workflow that runs when it cannot find anything teaches people to ignore its result.

## Not doing: parallel workers

`workers: 1` stays. The tests share one ComfyUI and reset its **server-side** settings between tests, so parallel workers would clobber each other — the exact problem the isolation baseline in #34 was added to fix. It would need one ComfyUI per worker, and the setup is only 12% of the run, so the trade is poor.

## On the number

**I don't have a measured saving yet, and I'm not going to estimate one.**

My first attempt timed the suite while background agents were driving the same ComfyUI instance — that measured contention, not this change, and produced one spurious failure from an agent altering a shared setting mid-test. Ironically the same server-side state race #34 exists to prevent, caused by me running two things against one instance. A clean re-run is in flight.

Note the real number will come from CI on merge to `test`, not from this PR: the path filters mean the workflow no longer runs on pull requests. Baseline to compare against is **406s of test time in an 8.8-minute run**.

The change itself doesn't depend on the timing — the fresh-context behaviour is verified, and the removed work was doing nothing either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
