### PR TITLE
Shard the browser suite across three runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,9 +35,16 @@ concurrency:
 
 jobs:
   browser:
-    name: Playwright against a real ComfyUI
+    name: Browser tests (shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
+
+    strategy:
+      # Keep the other shards running when one fails: a red shard usually means one broken
+      # test, and cancelling the rest hides whether anything else broke too.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Check out the extension
@@ -64,6 +71,13 @@ jobs:
 
       # CPU-only torch: these tests never execute a workflow, they only need ComfyUI's
       # frontend to load. The default wheels would pull in CUDA for no benefit.
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('ComfyUI/requirements.txt') }}
+          restore-keys: pip-${{ runner.os }}-
+
       - name: Install ComfyUI dependencies
         working-directory: ComfyUI
         run: |
@@ -135,13 +149,13 @@ jobs:
         working-directory: extension/e2e
         env:
           COMFYUI_URL: http://127.0.0.1:8188
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3
 
       - name: Upload report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: |
             extension/e2e/playwright-report/
             extension/e2e/test-results/
@@ -151,6 +165,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: comfyui-log
+          name: comfyui-log-shard-${{ matrix.shard }}
           path: ComfyUI/comfyui.log
           retention-days: 7


### PR DESCRIPTION
CI-only. Follows #46, which wasn't enough.

## Why #46 wasn't enough

Removing the redundant page loads bought about **10%**, not the step change the run needed. The reason is structural:

```
57 tests × one ComfyUI page load in beforeEach  ≈  285s
suite total                                        406s
```

That load can't be removed without giving up per-test isolation, which is what makes the suite trustworthy.

**Parallel workers aren't available either** — the tests share one ComfyUI and reset its *server-side* settings between tests, so workers would clobber each other. That's the constraint documented when the isolation baseline went in (#34), and it hasn't changed.

## Sharding sidesteps both

Each shard runs on **its own runner with its own ComfyUI**, so isolation is preserved exactly as it is today, and the test time divides three ways. Playwright splits by file — verified with `--list`: **20 / 22 / 16**.

## The trade, stated plainly

Setup is paid three times instead of once. It was 12% of a single run, so this spends roughly two extra minutes of *runner* time to take several minutes off the **wall clock** — the number anyone waiting on a merge actually experiences. Caching pip downloads takes some of that back.

If runner minutes ever matter more than latency here, this is the change to revisit first.

## Also

`fail-fast: false` — a red shard usually means one broken test, and cancelling the others hides whether anything else broke with it. Report and log artifacts are named per shard so they don't collide.

## On the expected number

Arithmetic says ~117s setup + ~135s tests ≈ **4 minutes**, against 8–10 today. I'm not claiming that until a run shows it — my last two predictions about this workflow were both wrong (I assumed torch install dominated; it was 12%, and I assumed removing page loads would be decisive; it was 10%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
