### PR TITLE
ci: type check the TypeScript (tsc --noEmit, 19 errors to 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Vite strips the types on the way to js/main.js without ever checking them, so until
+      # this step existed nothing in the project compiled the TypeScript. It is cheap and it
+      # fails on the annotations themselves, before the tests have to run anything.
+      - name: Type check
+        run: npm run typecheck
+
       - name: Unit tests
         run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,14 @@
 {
-  "name": "comfyui-housekeeper",
+  "name": "agent-ae09a2cbcbcc32ea0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
         "@comfyorg/comfyui-frontend-types": "^1.22.1",
+        "@types/node": "^22.20.1",
         "esbuild": "^0.25.0",
+        "typescript": "^5.6.3",
         "vite": "^6.3.5"
       },
       "engines": {
@@ -821,6 +823,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
@@ -1185,6 +1197,27 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "devDependencies": {
     "@comfyorg/comfyui-frontend-types": "^1.22.1",
+    "@types/node": "^22.20.1",
     "esbuild": "^0.25.0",
+    "typescript": "^5.6.3",
     "vite": "^6.3.5"
   },
   "scripts": {
     "build": "vite build",
     "test": "node --test tests/*.test.mjs",
-    "test:leveling": "node --test tests/leveling.test.mjs"
+    "test:leveling": "node --test tests/leveling.test.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "engines": {
     "node": ">=18"

--- a/src/types/litegraph.d.ts
+++ b/src/types/litegraph.d.ts
@@ -1,0 +1,15 @@
+import type { LGraphNode } from '@comfyorg/litegraph'
+
+// ComfyUI stamps `comfyClass` onto the node constructor when it registers a node type, but
+// the property is a ComfyUI addition and litegraph's own LGraphNodeConstructor does not
+// declare it. src/main.ts reads it in nodeCreated() to tell its own nodes apart from every
+// other node on the graph, which is a TS2339 against the upstream type.
+//
+// Declared here rather than in src/main.ts so the source - and therefore the committed
+// js/main.js bundle - is untouched. Type parameters must match the upstream declaration
+// exactly for the interfaces to merge.
+declare module '@comfyorg/litegraph' {
+    interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
+        comfyClass?: string
+    }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,21 @@
+// Ambient declarations for the module specifiers Vite resolves but tsc cannot.
+//
+// Nothing here describes application types; it only tells the compiler what the bundler
+// already knows. See src/types/litegraph.d.ts for the one real type gap.
+
+// Vite turns `import icon from '../icons/x.svg?url'` into the emitted asset path, a plain
+// string. tsc has no notion of the `?url` query, so every icon import in src/main.ts is a
+// TS2307 without this.
+declare module '*.svg?url' {
+    const src: string
+    export default src
+}
+
+// ComfyUI serves its own frontend scripts from web/scripts/, which the installed bundle
+// reaches as ../../../scripts/app.js from custom_nodes/<pack>/js/. No such file exists in
+// this repo - vite.config.mts lists it in rollupOptions.external for exactly that reason -
+// so the specifier resolves in the browser and nowhere else. Declaring it keeps `app`
+// typed without checking a stub into the tree.
+declare module '*/scripts/app.js' {
+    export const app: import('@comfyorg/comfyui-frontend-types').ComfyApp
+}


### PR DESCRIPTION
Closes #55.

Adds `typescript` as a devDependency, a `typecheck` script (`tsc --noEmit -p tsconfig.json`), and a `Type check` step in the frontend CI job, placed after `npm ci` and before the unit tests.

`src/main.ts` is untouched, so `js/main.js` is unchanged and still reproduces byte-identically from source.

## Before

`./node_modules/.bin/tsc --noEmit -p tsconfig.json` with `typescript@5.6.3`, against the repo's existing `tsconfig.json`:

```
src/main.ts(1,21): error TS2307: Cannot find module '../../../scripts/app.js' or its corresponding type declarations.
src/main.ts(9,25): error TS2307: Cannot find module '../icons/housekeeper.svg?url' or its corresponding type declarations.
src/main.ts(10,29): error TS2307: Cannot find module '../icons/collapse.svg?url' or its corresponding type declarations.
src/main.ts(11,30): error TS2307: Cannot find module '../icons/left.svg?url' or its corresponding type declarations.
src/main.ts(12,31): error TS2307: Cannot find module '../icons/right.svg?url' or its corresponding type declarations.
src/main.ts(13,29): error TS2307: Cannot find module '../icons/top.svg?url' or its corresponding type declarations.
src/main.ts(14,32): error TS2307: Cannot find module '../icons/bottom.svg?url' or its corresponding type declarations.
src/main.ts(15,32): error TS2307: Cannot find module '../icons/width-center.svg?url' or its corresponding type declarations.
src/main.ts(16,33): error TS2307: Cannot find module '../icons/height-center.svg?url' or its corresponding type declarations.
src/main.ts(17,29): error TS2307: Cannot find module '../icons/width-max.svg?url' or its corresponding type declarations.
src/main.ts(18,29): error TS2307: Cannot find module '../icons/width-min.svg?url' or its corresponding type declarations.
src/main.ts(19,30): error TS2307: Cannot find module '../icons/height-max.svg?url' or its corresponding type declarations.
src/main.ts(20,30): error TS2307: Cannot find module '../icons/height-min.svg?url' or its corresponding type declarations.
src/main.ts(21,28): error TS2307: Cannot find module '../icons/size-max.svg?url' or its corresponding type declarations.
src/main.ts(22,28): error TS2307: Cannot find module '../icons/size-min.svg?url' or its corresponding type declarations.
src/main.ts(23,35): error TS2307: Cannot find module '../icons/horizontal-flow.svg?url' or its corresponding type declarations.
src/main.ts(24,33): error TS2307: Cannot find module '../icons/vertical-flow.svg?url' or its corresponding type declarations.
src/main.ts(159,30): error TS2339: Property 'comfyClass' does not exist on type 'LGraphNodeConstructor<LGraphNode>'.
vite.config.mts(1,36): error TS2307: Cannot find module 'node:url' or its corresponding type declarations.
```

19 errors, matching the issue's count. The breakdown differs slightly from the issue's: the 18 `TS2307`s are not all icon imports. They are 16 icon imports, plus `../../../scripts/app.js`, plus `node:url` in `vite.config.mts`.

## After

```
$ ./node_modules/.bin/tsc --version
Version 5.6.3
$ ./node_modules/.bin/tsc --noEmit -p tsconfig.json
$ echo $?
0
```

(Use `./node_modules/.bin/tsc`, not `npx tsc` — on npm, `tsc` is an unrelated package that prints a banner and exits 0.)

## What the errors actually were

Eighteen of the nineteen were the compiler not knowing something the bundler already knows. They are declarations, not type debt, and `src/vite-env.d.ts` covers them:

- **16 icon imports.** Vite resolves `../icons/x.svg?url` to the emitted asset path, a string. tsc has no notion of the `?url` query, so each import is a missing module. `declare module '*.svg?url'` closes all 16.
- **`../../../scripts/app.js`.** ComfyUI serves its own frontend scripts from `web/scripts/`; the installed bundle reaches them relative to `custom_nodes/<pack>/js/`. The path resolves in the browser and nowhere on disk, which is why `vite.config.mts` already lists it in `rollupOptions.external`. Declared with its one export typed as `ComfyApp`, rather than checking a stub file into the tree.
- **`node:url` in `vite.config.mts`.** The config file is inside the project, so it gets checked too. Fixed by adding `@types/node`.

That leaves one real gap, the one the issue identified: `comfyClass` is a property ComfyUI stamps onto node constructors when it registers a node type, and litegraph's `LGraphNodeConstructor` does not declare it. `src/types/litegraph.d.ts` augments the interface with an optional `comfyClass?: string`.

The augmentation, rather than a change at the call site in `src/main.ts`, is deliberate: `js/main.js` is a committed build artifact, so any edit to the source forces a bundle rebuild. Keeping the source untouched keeps this PR's diff off the minified file.

Both fixes are load-bearing rather than incidental — removing `src/types/litegraph.d.ts` brings back exactly `src/main.ts(159,30): error TS2339`, and the check is not vacuous: `--listFiles` shows it covering `src/main.ts` and `vite.config.mts`, and a deliberately broken assignment in a scratch file under `src/` fails the run with exit 2.

As #55 notes, the source is `any`-heavy around every ComfyUI object, so this will not catch much today. Its value is that it holds the line at zero and gives the types upgrade in #56 something to measure against.

## Verification

- `npm run typecheck` — 0 errors, exit 0.
- `npm run build && git diff --exit-code js/` — clean, bundle byte-identical.
- `npm test` — 27 pass, 0 fail.
