### PR TITLE
test(e2e): place installGraph fixture nodes through the pos accessor

### DIFF
--- a/e2e/tests/helpers/comfyui.ts
+++ b/e2e/tests/helpers/comfyui.ts
@@ -229,8 +229,11 @@ export async function installGraph(
         }
 
         graph.add(node)
-        node.pos[0] = spec.x
-        node.pos[1] = spec.y
+        // Through the accessor, never node.pos[0]/[1]. Nodes 2.0's layout store is only
+        // updated by `set pos`; an indexed write mutates the underlying array behind its
+        // back and the store writes its own value - litegraph's default [10, 10] - back over
+        // it within a frame of graph.add(). See #67.
+        node.pos = [spec.x, spec.y]
         node.setSize?.([spec.width ?? 180, spec.height ?? 100])
         if (spec.minSize) {
           const minSize = [...spec.minSize]
@@ -255,8 +258,10 @@ export async function installGraph(
       for (const node of graph._nodes) node.is_selected = selected.includes(node)
 
       canvas.ds.scale = 1
-      canvas.ds.offset[0] = 180
-      canvas.ds.offset[1] = 150
+      // DragAndScale.offset is an accessor pair too. Unlike node.pos the indexed form does
+      // currently survive under Nodes 2.0 (measured), but there is no reason to keep the
+      // pattern that #67 is about where the setter is right there.
+      canvas.ds.offset = [180, 150]
       canvas.setDirty?.(true, true)
       graph.setDirtyCanvas?.(true, true)
       canvas.emitAfterChange?.()
@@ -265,6 +270,22 @@ export async function installGraph(
   )
 
   await page.waitForTimeout(650)
+
+  // The fixture is a precondition of every caller, so prove it took rather than letting a
+  // collapsed layout reach the assertions. Under #67 it did not take on the Vue renderer and
+  // five tests failed on arithmetic that read as five unrelated bugs; sampled after the settle
+  // above, because that is where the layout store's write-back landed.
+  const placed = await page.evaluate(() =>
+    ((window as any).app.graph.nodes as any[]).map((node) => [
+      String(node.title),
+      Math.round(node.pos[0]),
+      Math.round(node.pos[1])
+    ])
+  )
+  expect(
+    placed,
+    'installGraph could not place its nodes - the fixture is wrong, so nothing measured against it means anything'
+  ).toEqual(specs.map((spec) => [spec.title, spec.x, spec.y]))
 }
 
 export async function selectNodes(page: Page, titles: string[]) {


### PR DESCRIPTION
Closes #67.

`installGraph()` placed its fixture nodes with indexed writes:

```ts
graph.add(node)
node.pos[0] = spec.x
node.pos[1] = spec.y
```

`node.pos` is a getter/setter pair over a stable `Float64Array`, so the write lands and reads
back correctly. But under Nodes 2.0 the Vue layout store owns the position and is only updated
by `set pos`; an indexed write mutates the array behind its back, and within a frame of
`graph.add()` the store writes its own value — litegraph's default `[10, 10]` — back over it.
`installGraph()` then waits 650 ms, so every caller saw a fixture collapsed onto a single point.
This is a harness bug only; the legacy canvas has nothing that writes back, which is why it was
invisible outside the Vue leg.

The fix is `node.pos = [spec.x, spec.y]`. `set pos` is litegraph's own accessor and behaves
identically on both renderers, so there is no renderer branch here.

## Measured

ComfyUI v0.32.0, `comfyui-frontend-package` 1.48.7, Chrome 151, isolated install on :8188, served
`main.js` md5-verified against the tree (`5db106292a680cb6476dab8120140751`). No change to
`src/main.ts` or `js/main.js`.

| leg | before | after |
|---|---|---|
| `COMFYUI_RENDERER=vue` | 8 failed, 68 passed, 1 skipped | **3 failed**, 73 passed, 1 skipped |
| default canvas renderer | 0 failed, 74 passed, 3 skipped | 0 failed, 74 passed, 3 skipped |

Five tests go green, and they are the five that never reached a Housekeeper command:
`flow-leveling :: H-Flow creates five dependency columns and preserves prior Y order`, both
`rebindable-shortcuts` tests, and both `subgraph` tests. Two of them were failing on the
fixture's own precondition assertion.

### What still fails, and who owns it

| test | issue |
|---|---|
| `vue-renderer :: aligning moves the nodes on screen, not only in the graph` | #52 — product bug, position writes in `src/main.ts` bypass the accessor |
| `pinned :: a pinned node is not resized` | #68 — Nodes 2.0's 225px minimum node width |
| `geometry :: Size-Min preview matches the applied node bounds` | #68 — same |

#52 is deliberately not fixed here. It is the same class of bug in `src/main.ts`, but the two
are independent: fixing this does not touch #52 and fixing #52 does not touch this.

### `vue-renderer` now fails for the right reason

Worth stating because it is the difference between a test that proves #52 and one that only
looks like it does. Before this change that spec compared against a degenerate fixture — all
three nodes at `[10,10]`, drawn on top of each other, so `drawnBefore` was three copies of one
point:

```
Expected: not {"first": [190, 130], "second": [190, 130], "third": [190, 130]}
```

After it, the fixture is properly spread and the spec fails on a real layout:

```
Expected: not {"first": [300, 240], "second": [640, 420], "third": [980, 600]}
```

Same verdict, now reached against something worth measuring. This is the failure to watch while
fixing #52.

## Audit

Every geometry write in `e2e/tests/helpers/comfyui.ts` was checked against the accessors
litegraph provides, not just the one #67 names.

- `installGraph()` — `node.pos[0]/[1]`: the bug. Fixed.
- `installGraph()` — `canvas.ds.offset[0]/[1]`: the same shape of mistake. `DragAndScale.offset`
  is an accessor pair (confirmed on the instance's prototype chain), so the indexed form bypasses
  `set offset`. Measured under Nodes 2.0, this one does currently stick: the value survives the
  settle, `ds.state.offset` agrees, and replaying the identical numbers through the accessor moves
  nothing on screen. So it is not a second cause of the eight failures. Converted anyway — the
  setter is right there and the reason it works today is incidental to how the state proxy
  happens to be observed.
- `addGroup()` already used `created.pos = [...]` / `created.size = [...]`; `setNodeSize()` and
  `installGraph()`'s sizing already used `setSize()`. No change needed.
- `snapshots()`, `projectedNodeRects()` read `node.pos[0]` / `node.size[0]`. Indexed reads are
  fine — the getter hands back the same array — and left alone.
- No indexed `node.size[...]` writes exist in the helper.

Outside the helper, `tests/geometry.spec.ts` sets `canvas.ds.offset[0]/[1]` in one test. Same
observation as above: measured to work, not a cause of any failure. Left alone to keep this diff
to the file the issue is about.

`installGraph()` also gained a guard: after the 650 ms settle it asserts the nodes are where the
spec asked for them. #67 recommends it, and it is what turns this class of regression into one
legible failure instead of five unrelated-looking arithmetic ones.

`npm test` 27/27 and `npm run typecheck` clean.
